### PR TITLE
Keep HttpListener running, regardless of errors

### DIFF
--- a/Src/Metrics/Visualization/MetricsHttpListener.cs
+++ b/Src/Metrics/Visualization/MetricsHttpListener.cs
@@ -38,12 +38,11 @@ namespace Metrics.Visualization
                 {
                     ProcessRequest(this.httpListener.GetContext());
                 }
-                catch (HttpListenerException ex)
+                    // ReSharper disable EmptyGeneralCatchClause
+                catch (Exception)
+                    // ReSharper restore EmptyGeneralCatchClause
                 {
-                    if (ex.ErrorCode != 995) // IO operation aborted
-                    {
-                        throw;
-                    }
+                    // Keep listener running, regardless of errors.
                 }
             }
         }


### PR DESCRIPTION
We found that after ~2 hours in production use the metrics endpoint stopped responding. I believe this is due to some exception happening inside while processing a request. Since `Task` error are swallowed by the runtime the `HttpListener` task just goes away and we are no longer able to see metrics.

If you merge this, please also create a new `net40` release. Thanks!
