### PR TITLE
Fixes #50 and #51

### DIFF
--- a/Src/Metrics/Metric.cs
+++ b/Src/Metrics/Metric.cs
@@ -16,6 +16,7 @@ namespace Metrics
         static Metric()
         {
             globalContext = new DefaultMetricsContext(MetricsConfig.GetGlobalContextName());
+            MetricsConfig.CheckMetricsEnabledDisabled();
             config = new MetricsConfig(globalContext);
             config.ApplySettingsFromConfigFile();
         }

--- a/Src/Metrics/MetricsConfig.cs
+++ b/Src/Metrics/MetricsConfig.cs
@@ -18,11 +18,11 @@ namespace Metrics
         private Func<HealthStatus> healthStatus;
         private MetricsHttpListener listener;
 
-        private static readonly bool globalyDisabled;
+        private static bool globalyDisabled;
 
         private bool isDisabled = MetricsConfig.globalyDisabled;
 
-        static MetricsConfig()
+        public static void CheckMetricsEnabledDisabled()
         {
             globalyDisabled = ConfigureMetricsEnabledDisabled();
         }


### PR DESCRIPTION
One static constructor requires the other constructor to finish creating
a cyclic loop. This is easily fixed by removing static constructor for
MetricsConfig and introducing a public static method. This method can be
called from Metric class.

Minimal changes, seems to work for me, but not sure about wider
implications. Please check and accept this pull request if all's good.
