### PR TITLE
Timer extensions

### DIFF
--- a/Src/Metrics/Core/NullMetricsRegistry.cs
+++ b/Src/Metrics/Core/NullMetricsRegistry.cs
@@ -4,9 +4,9 @@ using Metrics.MetricData;
 
 namespace Metrics.Core
 {
-    public sealed class NullMetricsRegistry : MetricsRegistry
+    public sealed partial class NullMetricsRegistry : MetricsRegistry
     {
-        private struct NullMetric : Counter, Meter, Histogram, Timer, TimerContext, RegistryDataProvider
+        private partial struct NullMetric : Counter, Meter, Histogram, Timer, TimerContext, RegistryDataProvider
         {
             public static readonly NullMetric Instance = new NullMetric();
 

--- a/Src/Metrics/Core/NullMetricsRegistry.generated.cs
+++ b/Src/Metrics/Core/NullMetricsRegistry.generated.cs
@@ -13,6 +13,12 @@ namespace Metrics.Core
             /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null) { return action(arg1, arg2); }
 
@@ -23,6 +29,13 @@ namespace Metrics.Core
             /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null) { return action(arg1, arg2, arg3); }
 
@@ -34,6 +47,14 @@ namespace Metrics.Core
             /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null) { return action(arg1, arg2, arg3, arg4); }
 
@@ -46,6 +67,15 @@ namespace Metrics.Core
             /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5); }
 
@@ -59,6 +89,16 @@ namespace Metrics.Core
             /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6); }
 
@@ -73,6 +113,17 @@ namespace Metrics.Core
             /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7); }
 
@@ -88,6 +139,18 @@ namespace Metrics.Core
             /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); }
 
@@ -104,6 +167,19 @@ namespace Metrics.Core
             /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); }
 
@@ -121,6 +197,20 @@ namespace Metrics.Core
             /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); }
 
@@ -139,6 +229,21 @@ namespace Metrics.Core
             /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); }
 
@@ -158,6 +263,22 @@ namespace Metrics.Core
             /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); }
 
@@ -178,6 +299,23 @@ namespace Metrics.Core
             /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); }
 
@@ -199,6 +337,24 @@ namespace Metrics.Core
             /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); }
 
@@ -221,6 +377,25 @@ namespace Metrics.Core
             /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg15">The fifteenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); }
 
@@ -244,6 +419,26 @@ namespace Metrics.Core
             /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg15">The fifteenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="arg16">The sixteenth parameter of the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); }
 
@@ -252,6 +447,12 @@ namespace Metrics.Core
             /// </summary>
             /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null) { action(arg1, arg2); }
 
@@ -261,6 +462,13 @@ namespace Metrics.Core
             /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null) { action(arg1, arg2, arg3); }
 
@@ -271,6 +479,14 @@ namespace Metrics.Core
             /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null) { action(arg1, arg2, arg3, arg4); }
 
@@ -282,6 +498,15 @@ namespace Metrics.Core
             /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5); }
 
@@ -294,6 +519,16 @@ namespace Metrics.Core
             /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6); }
 
@@ -307,6 +542,17 @@ namespace Metrics.Core
             /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7); }
 
@@ -321,6 +567,18 @@ namespace Metrics.Core
             /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); }
 
@@ -336,6 +594,19 @@ namespace Metrics.Core
             /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); }
 
@@ -352,6 +623,20 @@ namespace Metrics.Core
             /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); }
 
@@ -369,6 +654,21 @@ namespace Metrics.Core
             /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); }
 
@@ -387,6 +687,22 @@ namespace Metrics.Core
             /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); }
 
@@ -406,6 +722,23 @@ namespace Metrics.Core
             /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); }
 
@@ -426,6 +759,24 @@ namespace Metrics.Core
             /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); }
 
@@ -447,6 +798,25 @@ namespace Metrics.Core
             /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg15">The fifteenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); }
 
@@ -469,6 +839,26 @@ namespace Metrics.Core
             /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg15">The fifteenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="arg16">The sixteenth parameter to the <paramref name="action"/> delegate.</param>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); }
 

--- a/Src/Metrics/Core/NullMetricsRegistry.generated.cs
+++ b/Src/Metrics/Core/NullMetricsRegistry.generated.cs
@@ -1,0 +1,478 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Metrics.Core
+{
+    public sealed partial class NullMetricsRegistry
+	{
+		private partial struct NullMetric
+		{
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null) { return action(arg1, arg2); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null) { return action(arg1, arg2, arg3); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null) { return action(arg1, arg2, arg3, arg4); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null) { action(arg1, arg2); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null) { action(arg1, arg2, arg3); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null) { action(arg1, arg2, arg3, arg4); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); }
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); }
+
+		}
+	}
+}
+

--- a/Src/Metrics/Core/NullMetricsRegistry.generated.cs
+++ b/Src/Metrics/Core/NullMetricsRegistry.generated.cs
@@ -13,12 +13,12 @@ namespace Metrics.Core
             /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null) { return action(arg1, arg2); }
 
@@ -29,13 +29,13 @@ namespace Metrics.Core
             /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null) { return action(arg1, arg2, arg3); }
 
@@ -47,14 +47,14 @@ namespace Metrics.Core
             /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null) { return action(arg1, arg2, arg3, arg4); }
 
@@ -67,15 +67,15 @@ namespace Metrics.Core
             /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5); }
 
@@ -89,16 +89,16 @@ namespace Metrics.Core
             /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6); }
 
@@ -113,17 +113,17 @@ namespace Metrics.Core
             /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7); }
 
@@ -139,18 +139,18 @@ namespace Metrics.Core
             /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); }
 
@@ -167,19 +167,19 @@ namespace Metrics.Core
             /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); }
 
@@ -197,20 +197,20 @@ namespace Metrics.Core
             /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); }
 
@@ -229,21 +229,21 @@ namespace Metrics.Core
             /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); }
 
@@ -263,22 +263,22 @@ namespace Metrics.Core
             /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); }
 
@@ -299,23 +299,23 @@ namespace Metrics.Core
             /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); }
 
@@ -337,24 +337,24 @@ namespace Metrics.Core
             /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); }
 
@@ -377,25 +377,25 @@ namespace Metrics.Core
             /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg15">The fifteenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg15">The fifteenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); }
 
@@ -419,26 +419,26 @@ namespace Metrics.Core
             /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg15">The fifteenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="arg16">The sixteenth parameter of the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg15">The fifteenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg16">The sixteenth parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); }
 
@@ -447,12 +447,12 @@ namespace Metrics.Core
             /// </summary>
             /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null) { action(arg1, arg2); }
 
@@ -462,13 +462,13 @@ namespace Metrics.Core
             /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null) { action(arg1, arg2, arg3); }
 
@@ -479,14 +479,14 @@ namespace Metrics.Core
             /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null) { action(arg1, arg2, arg3, arg4); }
 
@@ -498,15 +498,15 @@ namespace Metrics.Core
             /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5); }
 
@@ -519,16 +519,16 @@ namespace Metrics.Core
             /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6); }
 
@@ -542,17 +542,17 @@ namespace Metrics.Core
             /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7); }
 
@@ -567,18 +567,18 @@ namespace Metrics.Core
             /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); }
 
@@ -594,19 +594,19 @@ namespace Metrics.Core
             /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); }
 
@@ -623,20 +623,20 @@ namespace Metrics.Core
             /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); }
 
@@ -654,21 +654,21 @@ namespace Metrics.Core
             /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); }
 
@@ -687,22 +687,22 @@ namespace Metrics.Core
             /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); }
 
@@ -722,23 +722,23 @@ namespace Metrics.Core
             /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); }
 
@@ -759,24 +759,24 @@ namespace Metrics.Core
             /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); }
 
@@ -798,25 +798,25 @@ namespace Metrics.Core
             /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg15">The fifteenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg15">The fifteenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); }
 
@@ -839,26 +839,26 @@ namespace Metrics.Core
             /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
             /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-			/// <param name="action">Action to run and record time for.</param>
-			/// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg15">The fifteenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="arg16">The sixteenth parameter to the <paramref name="action"/> delegate.</param>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="action">Action to run and record time for.</param>
+            /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg15">The fifteenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg16">The sixteenth parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); }
 

--- a/Src/Metrics/Core/NullMetricsRegistry.generated.cs
+++ b/Src/Metrics/Core/NullMetricsRegistry.generated.cs
@@ -4,475 +4,475 @@ using System.Diagnostics.CodeAnalysis;
 namespace Metrics.Core
 {
     public sealed partial class NullMetricsRegistry
-	{
-		private partial struct NullMetric
-		{
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null) { return action(arg1, arg2); }
+    {
+        private partial struct NullMetric
+        {
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null) { return action(arg1, arg2); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null) { return action(arg1, arg2, arg3); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null) { return action(arg1, arg2, arg3); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null) { return action(arg1, arg2, arg3, arg4); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null) { return action(arg1, arg2, arg3, arg4); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null) { return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null) { action(arg1, arg2); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null) { action(arg1, arg2); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null) { action(arg1, arg2, arg3); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null) { action(arg1, arg2, arg3); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null) { action(arg1, arg2, arg3, arg4); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null) { action(arg1, arg2, arg3, arg4); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); }
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); }
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
+            /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null) { action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16); }
 
-		}
-	}
+        }
+    }
 }
 

--- a/Src/Metrics/Core/NullMetricsRegistry.tt
+++ b/Src/Metrics/Core/NullMetricsRegistry.tt
@@ -29,13 +29,13 @@ for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
             /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
             /// <typeparam name="TResult"></typeparam>
-			/// <param name="action">Action to run and record time for.</param>
+            /// <param name="action">Action to run and record time for.</param>
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
-			/// <param name="arg<#= typeIndex #>">The <#= ConvertToOrdinal(typeIndex) #> parameter of the <paramref name="action"/> delegate.</param>
+            /// <param name="arg<#= typeIndex #>">The <#= ConvertToOrdinal(typeIndex) #> parameter of the <paramref name="action"/> delegate.</param>
 <# } #>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null) { return action(<#= paramList #>); }
 
@@ -54,13 +54,13 @@ for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
             /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
-			/// <param name="action">Action to run and record time for.</param>
+            /// <param name="action">Action to run and record time for.</param>
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
-			/// <param name="arg<#= typeIndex #>">The <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</param>
+            /// <param name="arg<#= typeIndex #>">The <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</param>
 <# } #>
-			/// <param name="userValue">A custom user value that will be associated to the results.
-			/// Useful for tracking (for example) for which id the max or min value was recorded.
-			/// </param>
+            /// <param name="userValue">A custom user value that will be associated to the results.
+            /// Useful for tracking (for example) for which id the max or min value was recorded.
+            /// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null) { action(<#= paramList #>); }
 

--- a/Src/Metrics/Core/NullMetricsRegistry.tt
+++ b/Src/Metrics/Core/NullMetricsRegistry.tt
@@ -29,6 +29,13 @@ for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
             /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
             /// <typeparam name="TResult"></typeparam>
+			/// <param name="action">Action to run and record time for.</param>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+			/// <param name="arg<#= typeIndex #>">The <#= ConvertToOrdinal(typeIndex) #> parameter of the <paramref name="action"/> delegate.</param>
+<# } #>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null) { return action(<#= paramList #>); }
 
@@ -47,6 +54,13 @@ for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
             /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
+			/// <param name="action">Action to run and record time for.</param>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+			/// <param name="arg<#= typeIndex #>">The <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</param>
+<# } #>
+			/// <param name="userValue">A custom user value that will be associated to the results.
+			/// Useful for tracking (for example) for which id the max or min value was recorded.
+			/// </param>
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
             public void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null) { action(<#= paramList #>); }
 

--- a/Src/Metrics/Core/NullMetricsRegistry.tt
+++ b/Src/Metrics/Core/NullMetricsRegistry.tt
@@ -11,47 +11,47 @@ using System.Diagnostics.CodeAnalysis;
 namespace Metrics.Core
 {
     public sealed partial class NullMetricsRegistry
-	{
-		private partial struct NullMetric
-		{
+    {
+        private partial struct NullMetric
+        {
 <#
 for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 {
-	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
-	var typeList = GetGenericList(typeCount, GenericTypeFormat);
-	var argList = GetGenericList(typeCount, GenericArgumentFormat);
-	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+    var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+    var typeList = GetGenericList(typeCount, GenericTypeFormat);
+    var argList = GetGenericList(typeCount, GenericArgumentFormat);
+    var paramList = GetGenericList(typeCount, GenericParameterFormat);
 #>
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
-	/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null) { return action(<#= paramList #>); }
+            /// <typeparam name="TResult"></typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null) { return action(<#= paramList #>); }
 
 <# } #>
 <#
 for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 {
-	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
-	var typeList = GetGenericList(typeCount, GenericTypeFormat);
-	var argList = GetGenericList(typeCount, GenericArgumentFormat);
-	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+    var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+    var typeList = GetGenericList(typeCount, GenericTypeFormat);
+    var argList = GetGenericList(typeCount, GenericArgumentFormat);
+    var paramList = GetGenericList(typeCount, GenericParameterFormat);
 #>
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
+            /// <summary>
+            /// Runs the <paramref name="action"/> and records the time it took.
+            /// </summary>
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
-	/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+            /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	public void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null) { action(<#= paramList #>); }
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+            public void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null) { action(<#= paramList #>); }
 
 <# } #>
-		}
-	}
+        }
+    }
 }
 

--- a/Src/Metrics/Core/NullMetricsRegistry.tt
+++ b/Src/Metrics/Core/NullMetricsRegistry.tt
@@ -1,0 +1,57 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension="generated.cs" #>
+<#@ include file="..\GenericTypes.tt" #>
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Metrics.Core
+{
+    public sealed partial class NullMetricsRegistry
+	{
+		private partial struct NullMetric
+		{
+<#
+for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
+{
+	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+	var typeList = GetGenericList(typeCount, GenericTypeFormat);
+	var argList = GetGenericList(typeCount, GenericArgumentFormat);
+	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+#>
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+	/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+<# } #>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null) { return action(<#= paramList #>); }
+
+<# } #>
+<#
+for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
+{
+	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+	var typeList = GetGenericList(typeCount, GenericTypeFormat);
+	var argList = GetGenericList(typeCount, GenericArgumentFormat);
+	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+#>
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+	/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+<# } #>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	public void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null) { action(<#= paramList #>); }
+
+<# } #>
+		}
+	}
+}
+

--- a/Src/Metrics/Core/TimerMetric.cs
+++ b/Src/Metrics/Core/TimerMetric.cs
@@ -7,7 +7,7 @@ namespace Metrics.Core
 {
     public interface TimerImplementation : Timer, MetricValueProvider<TimerValue> { }
 
-    public sealed class TimerMetric : TimerImplementation, IDisposable
+    public sealed partial class TimerMetric : TimerImplementation, IDisposable
     {
         private readonly Clock clock;
         private readonly MeterImplementation meter;

--- a/Src/Metrics/Core/TimerMetric.generated.cs
+++ b/Src/Metrics/Core/TimerMetric.generated.cs
@@ -4,861 +4,861 @@ using System.Diagnostics.CodeAnalysis;
 namespace Metrics.Core
 {
     public sealed partial class TimerMetric
-	{
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+    {
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5, arg6);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5, arg6);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5, arg6);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5, arg6);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
-		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
-	}
+    }
 }

--- a/Src/Metrics/Core/TimerMetric.generated.cs
+++ b/Src/Metrics/Core/TimerMetric.generated.cs
@@ -10,7 +10,13 @@ namespace Metrics.Core
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null)
         {
@@ -33,7 +39,14 @@ namespace Metrics.Core
         /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null)
         {
@@ -57,7 +70,15 @@ namespace Metrics.Core
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null)
         {
@@ -82,7 +103,16 @@ namespace Metrics.Core
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null)
         {
@@ -108,7 +138,17 @@ namespace Metrics.Core
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null)
         {
@@ -135,7 +175,18 @@ namespace Metrics.Core
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null)
         {
@@ -163,7 +214,19 @@ namespace Metrics.Core
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null)
         {
@@ -192,7 +255,20 @@ namespace Metrics.Core
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null)
         {
@@ -222,7 +298,21 @@ namespace Metrics.Core
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null)
         {
@@ -253,7 +343,22 @@ namespace Metrics.Core
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null)
         {
@@ -285,7 +390,23 @@ namespace Metrics.Core
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null)
         {
@@ -318,7 +439,24 @@ namespace Metrics.Core
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null)
         {
@@ -352,7 +490,25 @@ namespace Metrics.Core
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null)
         {
@@ -387,7 +543,26 @@ namespace Metrics.Core
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg15">The fifteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null)
         {
@@ -423,7 +598,27 @@ namespace Metrics.Core
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg15">The fifteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg16">The sixteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null)
         {
@@ -445,6 +640,12 @@ namespace Metrics.Core
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null)
         {
@@ -467,6 +668,13 @@ namespace Metrics.Core
         /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null)
         {
@@ -490,6 +698,14 @@ namespace Metrics.Core
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null)
         {
@@ -514,6 +730,15 @@ namespace Metrics.Core
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null)
         {
@@ -539,6 +764,16 @@ namespace Metrics.Core
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null)
         {
@@ -565,6 +800,17 @@ namespace Metrics.Core
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null)
         {
@@ -592,6 +838,18 @@ namespace Metrics.Core
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null)
         {
@@ -620,6 +878,19 @@ namespace Metrics.Core
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null)
         {
@@ -649,6 +920,20 @@ namespace Metrics.Core
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null)
         {
@@ -679,6 +964,21 @@ namespace Metrics.Core
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null)
         {
@@ -710,6 +1010,22 @@ namespace Metrics.Core
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null)
         {
@@ -742,6 +1058,23 @@ namespace Metrics.Core
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null)
         {
@@ -775,6 +1108,24 @@ namespace Metrics.Core
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null)
         {
@@ -809,6 +1160,25 @@ namespace Metrics.Core
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg15">The fifteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null)
         {
@@ -844,6 +1214,26 @@ namespace Metrics.Core
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg15">The fifteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="arg16">The sixteenth parameter of the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null)
         {

--- a/Src/Metrics/Core/TimerMetric.generated.cs
+++ b/Src/Metrics/Core/TimerMetric.generated.cs
@@ -1,0 +1,864 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Metrics.Core
+{
+    public sealed partial class TimerMetric
+	{
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5, arg6);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5, arg6);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+	}
+}

--- a/Src/Metrics/Core/TimerMetric.tt
+++ b/Src/Metrics/Core/TimerMetric.tt
@@ -26,7 +26,14 @@ for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
         /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
-        /// <typeparam name="TResult"></typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+        /// <param name="arg<#= typeIndex #>">The <#= ConvertToOrdinal(typeIndex) #> parameter of the <paramref name="action"/> delegate.</param>
+<# } #>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <typeparam name="TResult">The type of the return value of the method that the <paramref name="action"/> delegate encapsulates.</typeparam>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null)
         {
@@ -58,6 +65,13 @@ for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
         /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
+        /// <param name="action">Action to run and record time for.</param>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+        /// <param name="arg<#= typeIndex #>">The <#= ConvertToOrdinal(typeIndex) #> parameter of the <paramref name="action"/> delegate.</param>
+<# } #>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         public void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null)
         {

--- a/Src/Metrics/Core/TimerMetric.tt
+++ b/Src/Metrics/Core/TimerMetric.tt
@@ -1,0 +1,79 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension="generated.cs" #>
+<#@ include file="..\GenericTypes.tt" #>
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Metrics.Core
+{
+    public sealed partial class TimerMetric
+	{
+<#
+for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
+{
+	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+	var typeList = GetGenericList(typeCount, GenericTypeFormat);
+	var argList = GetGenericList(typeCount, GenericArgumentFormat);
+	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+#>
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+		/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+<# } #>
+		/// <typeparam name="TResult"></typeparam>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				return action(<#= paramList #>);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+<# } #>
+<#
+for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
+{
+	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+	var typeList = GetGenericList(typeCount, GenericTypeFormat);
+	var argList = GetGenericList(typeCount, GenericArgumentFormat);
+	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+#>
+		/// <summary>
+		/// Runs the <paramref name="action"/> and records the time it took.
+		/// </summary>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+		/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+<# } #>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+		public void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null)
+		{
+			var start = this.clock.Nanoseconds;
+			try
+			{
+				counter.Increment();
+				action(<#= paramList #>);
+			}
+			finally
+			{
+				counter.Decrement();
+				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+			}
+		}
+
+<# } #>
+	}
+}

--- a/Src/Metrics/Core/TimerMetric.tt
+++ b/Src/Metrics/Core/TimerMetric.tt
@@ -11,69 +11,69 @@ using System.Diagnostics.CodeAnalysis;
 namespace Metrics.Core
 {
     public sealed partial class TimerMetric
-	{
+    {
 <#
 for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 {
-	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
-	var typeList = GetGenericList(typeCount, GenericTypeFormat);
-	var argList = GetGenericList(typeCount, GenericArgumentFormat);
-	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+    var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+    var typeList = GetGenericList(typeCount, GenericTypeFormat);
+    var argList = GetGenericList(typeCount, GenericArgumentFormat);
+    var paramList = GetGenericList(typeCount, GenericParameterFormat);
 #>
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
-		/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
-		/// <typeparam name="TResult"></typeparam>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				return action(<#= paramList #>);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                return action(<#= paramList #>);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
 <# } #>
 <#
 for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 {
-	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
-	var typeList = GetGenericList(typeCount, GenericTypeFormat);
-	var argList = GetGenericList(typeCount, GenericArgumentFormat);
-	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+    var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+    var typeList = GetGenericList(typeCount, GenericTypeFormat);
+    var argList = GetGenericList(typeCount, GenericArgumentFormat);
+    var paramList = GetGenericList(typeCount, GenericParameterFormat);
 #>
-		/// <summary>
-		/// Runs the <paramref name="action"/> and records the time it took.
-		/// </summary>
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
-		/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-		public void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null)
-		{
-			var start = this.clock.Nanoseconds;
-			try
-			{
-				counter.Increment();
-				action(<#= paramList #>);
-			}
-			finally
-			{
-				counter.Decrement();
-				Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
-			}
-		}
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        public void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null)
+        {
+            var start = this.clock.Nanoseconds;
+            try
+            {
+                counter.Increment();
+                action(<#= paramList #>);
+            }
+            finally
+            {
+                counter.Decrement();
+                Record(this.clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
 
 <# } #>
-	}
+    }
 }

--- a/Src/Metrics/GenericTypes.tt
+++ b/Src/Metrics/GenericTypes.tt
@@ -1,0 +1,28 @@
+﻿<#+
+/// <summary>
+/// Helper constants for T4 templates for generic types.
+/// </summary>
+
+private const int GenericTypeMax = 16;
+private const string GenericTypeFormat = "T{0}";
+private const string GenericArgumentFormat = "T{0} arg{0}";
+private const string GenericParameterFormat = "arg{0}";
+
+private static readonly string[] ordinalNumbers = new[] { "first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "nineth", "tenth", "eleventh", "twelfth", "thirteenth", "fourteenth", "fifteenth", "sixteenth" };
+private static readonly string[] wordNumbers = new[] { "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen" };
+
+public static string ConvertToWord(int number)
+{
+	return wordNumbers[number - 1];
+}
+
+public static string ConvertToOrdinal(int number)
+{
+	return ordinalNumbers[number - 1];
+}
+
+private static string GetGenericList(int typeCount, string format, string separator = ", ")
+{
+	return string.Join(separator, Enumerable.Range(1, typeCount).Select(n => string.Format(format, n)).ToArray());
+}
+#>

--- a/Src/Metrics/GenericTypes.tt
+++ b/Src/Metrics/GenericTypes.tt
@@ -13,16 +13,16 @@ private static readonly string[] wordNumbers = new[] { "one", "two", "three", "f
 
 public static string ConvertToWord(int number)
 {
-	return wordNumbers[number - 1];
+    return wordNumbers[number - 1];
 }
 
 public static string ConvertToOrdinal(int number)
 {
-	return ordinalNumbers[number - 1];
+    return ordinalNumbers[number - 1];
 }
 
 private static string GetGenericList(int typeCount, string format, string separator = ", ")
 {
-	return string.Join(separator, Enumerable.Range(1, typeCount).Select(n => string.Format(format, n)).ToArray());
+    return string.Join(separator, Enumerable.Range(1, typeCount).Select(n => string.Format(format, n)).ToArray());
 }
 #>

--- a/Src/Metrics/Metrics.csproj
+++ b/Src/Metrics/Metrics.csproj
@@ -192,7 +192,6 @@
       <LastGenOutput>TimerMetric.generated.cs</LastGenOutput>
     </None>
     <None Include="GenericTypes.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>GenericTypes.cs</LastGenOutput>
     </None>
     <None Include="packages.config" />

--- a/Src/Metrics/Metrics.csproj
+++ b/Src/Metrics/Metrics.csproj
@@ -55,6 +55,16 @@
     <Compile Include="Core\DefaultMetricsRegistry.cs" />
     <Compile Include="Core\DefaultDataProvider.cs" />
     <Compile Include="Core\DefaultRegistryDataProvider.cs" />
+    <Compile Include="Core\NullMetricsRegistry.generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>NullMetricsRegistry.tt</DependentUpon>
+    </Compile>
+    <Compile Include="Core\TimerMetric.generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>TimerMetric.tt</DependentUpon>
+    </Compile>
     <Compile Include="ElasticSearch\ElasticSearchConfigExtensions.cs" />
     <Compile Include="ElasticSearch\ElasticSearchReport.cs" />
     <Compile Include="Graphite\PickleGraphiteSender.cs" />
@@ -134,6 +144,11 @@
     <Compile Include="Sampling\UniformReservoir.cs" />
     <Compile Include="Metric.cs" />
     <Compile Include="Timer.cs" />
+    <Compile Include="Timer.generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Timer.tt</DependentUpon>
+    </Compile>
     <Compile Include="Unit.cs" />
     <Compile Include="Utils\ActionScheduler.cs" />
     <Compile Include="Utils\AppEnvironment.cs" />
@@ -168,7 +183,26 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Core\NullMetricsRegistry.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>NullMetricsRegistry.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Core\TimerMetric.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>TimerMetric.generated.cs</LastGenOutput>
+    </None>
+    <None Include="GenericTypes.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>GenericTypes.cs</LastGenOutput>
+    </None>
     <None Include="packages.config" />
+    <None Include="Timer.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Timer.generated.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Src/Metrics/Timer.cs
+++ b/Src/Metrics/Timer.cs
@@ -6,7 +6,7 @@ namespace Metrics
     /// A timer is basically a histogram of the duration of a type of event and a meter of the rate of its occurrence.
     /// <seealso cref="Histogram"/> and <seealso cref="Meter"/>
     /// </summary>
-    public interface Timer : ResetableMetric, Utils.IHideObjectMembers
+    public partial interface Timer : ResetableMetric, Utils.IHideObjectMembers
     {
         /// <summary>
         /// Manually record timer value

--- a/Src/Metrics/Timer.generated.cs
+++ b/Src/Metrics/Timer.generated.cs
@@ -1,0 +1,478 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Metrics
+{
+    /// <summary>
+    /// A timer is basically a histogram of the duration of a type of event and a meter of the rate of its occurrence.
+    /// <seealso cref="Histogram"/> and <seealso cref="Meter"/>
+    /// </summary>
+    public partial interface Timer
+	{
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null);
+
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null);
+
+	}
+}

--- a/Src/Metrics/Timer.generated.cs
+++ b/Src/Metrics/Timer.generated.cs
@@ -8,471 +8,471 @@ namespace Metrics
     /// <seealso cref="Histogram"/> and <seealso cref="Meter"/>
     /// </summary>
     public partial interface Timer
-	{
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null);
+    {
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null);
 
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
-	/// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	/// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null);
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
+        /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null);
 
-	}
+    }
 }

--- a/Src/Metrics/Timer.generated.cs
+++ b/Src/Metrics/Timer.generated.cs
@@ -3,10 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Metrics
 {
-    /// <summary>
-    /// A timer is basically a histogram of the duration of a type of event and a meter of the rate of its occurrence.
-    /// <seealso cref="Histogram"/> and <seealso cref="Meter"/>
-    /// </summary>
     public partial interface Timer
     {
         /// <summary>
@@ -14,7 +10,14 @@ namespace Metrics
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, TResult>(Func<T1, T2, TResult> action, T1 arg1, T2 arg2, string userValue = null);
 
@@ -24,7 +27,15 @@ namespace Metrics
         /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null);
 
@@ -35,7 +46,16 @@ namespace Metrics
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null);
 
@@ -47,7 +67,17 @@ namespace Metrics
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, TResult>(Func<T1, T2, T3, T4, T5, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null);
 
@@ -60,7 +90,18 @@ namespace Metrics
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, T6, TResult>(Func<T1, T2, T3, T4, T5, T6, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null);
 
@@ -74,7 +115,19 @@ namespace Metrics
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, T6, T7, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null);
 
@@ -89,7 +142,20 @@ namespace Metrics
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null);
 
@@ -105,7 +171,21 @@ namespace Metrics
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null);
 
@@ -122,7 +202,22 @@ namespace Metrics
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null);
 
@@ -140,7 +235,23 @@ namespace Metrics
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null);
 
@@ -159,7 +270,24 @@ namespace Metrics
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null);
 
@@ -179,7 +307,25 @@ namespace Metrics
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null);
 
@@ -200,7 +346,26 @@ namespace Metrics
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null);
 
@@ -222,7 +387,27 @@ namespace Metrics
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg15">The fifteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null);
 
@@ -245,7 +430,28 @@ namespace Metrics
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg15">The fifteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg16">The sixteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null);
 
@@ -254,6 +460,12 @@ namespace Metrics
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2, string userValue = null);
 
@@ -263,6 +475,13 @@ namespace Metrics
         /// <typeparam name="T1">The type of the first parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3>(Action<T1, T2, T3> action, T1 arg1, T2 arg2, T3 arg3, string userValue = null);
 
@@ -273,6 +492,14 @@ namespace Metrics
         /// <typeparam name="T2">The type of the second parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, string userValue = null);
 
@@ -284,6 +511,15 @@ namespace Metrics
         /// <typeparam name="T3">The type of the third parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, string userValue = null);
 
@@ -296,6 +532,16 @@ namespace Metrics
         /// <typeparam name="T4">The type of the fourth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, string userValue = null);
 
@@ -309,6 +555,17 @@ namespace Metrics
         /// <typeparam name="T5">The type of the fifth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, string userValue = null);
 
@@ -323,6 +580,18 @@ namespace Metrics
         /// <typeparam name="T6">The type of the sixth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, string userValue = null);
 
@@ -338,6 +607,19 @@ namespace Metrics
         /// <typeparam name="T7">The type of the seventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, string userValue = null);
 
@@ -354,6 +636,20 @@ namespace Metrics
         /// <typeparam name="T8">The type of the eighth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, string userValue = null);
 
@@ -371,6 +667,21 @@ namespace Metrics
         /// <typeparam name="T9">The type of the nineth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, string userValue = null);
 
@@ -389,6 +700,22 @@ namespace Metrics
         /// <typeparam name="T10">The type of the tenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, string userValue = null);
 
@@ -408,6 +735,23 @@ namespace Metrics
         /// <typeparam name="T11">The type of the eleventh parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, string userValue = null);
 
@@ -428,6 +772,24 @@ namespace Metrics
         /// <typeparam name="T12">The type of the twelfth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, string userValue = null);
 
@@ -449,6 +811,25 @@ namespace Metrics
         /// <typeparam name="T13">The type of the thirteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg15">The fifteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, string userValue = null);
 
@@ -471,6 +852,26 @@ namespace Metrics
         /// <typeparam name="T14">The type of the fourteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T15">The type of the fifteenth parameter to the <paramref name="action"/> delegate.</typeparam>
         /// <typeparam name="T16">The type of the sixteenth parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+        /// <param name="arg1">The first parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg2">The second parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg3">The third parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg4">The fourth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg5">The fifth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg6">The sixth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg7">The seventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg8">The eighth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg9">The nineth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg10">The tenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg11">The eleventh parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg12">The twelfth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg13">The thirteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg14">The fourteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg15">The fifteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="arg16">The sixteenth parameter to the <paramref name="action"/> delegate.</param>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, string userValue = null);
 

--- a/Src/Metrics/Timer.tt
+++ b/Src/Metrics/Timer.tt
@@ -10,10 +10,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Metrics
 {
-    /// <summary>
-    /// A timer is basically a histogram of the duration of a type of event and a meter of the rate of its occurrence.
-    /// <seealso cref="Histogram"/> and <seealso cref="Meter"/>
-    /// </summary>
     public partial interface Timer
     {
 <#
@@ -30,7 +26,15 @@ for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
         /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
-        /// <typeparam name="TResult"></typeparam>
+        /// <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
+        /// <param name="action">Action to run and record time for.</param>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+        /// <param name="arg<#= typeIndex #>">The <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</param>
+<# } #>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
+        /// <returns>The result of the <paramref name="action"/></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null);
 
@@ -49,6 +53,13 @@ for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
         /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
+        /// <param name="action">Action to run and record time for.</param>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+        /// <param name="arg<#= typeIndex #>">The <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</param>
+<# } #>
+        /// <param name="userValue">A custom user value that will be associated to the results.
+        /// Useful for tracking (for example) for which id the max or min value was recorded.
+        /// </param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
         void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null);
 

--- a/Src/Metrics/Timer.tt
+++ b/Src/Metrics/Timer.tt
@@ -1,0 +1,57 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension="generated.cs" #>
+<#@ include file="GenericTypes.tt" #>
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Metrics
+{
+    /// <summary>
+    /// A timer is basically a histogram of the duration of a type of event and a meter of the rate of its occurrence.
+    /// <seealso cref="Histogram"/> and <seealso cref="Meter"/>
+    /// </summary>
+    public partial interface Timer
+	{
+<#
+for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
+{
+	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+	var typeList = GetGenericList(typeCount, GenericTypeFormat);
+	var argList = GetGenericList(typeCount, GenericArgumentFormat);
+	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+#>
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+	/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+<# } #>
+    /// <typeparam name="TResult"></typeparam>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null);
+
+<# } #>
+<#
+for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
+{
+	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+	var typeList = GetGenericList(typeCount, GenericTypeFormat);
+	var argList = GetGenericList(typeCount, GenericArgumentFormat);
+	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+#>
+	/// <summary>
+	/// Runs the <paramref name="action"/> and records the time it took.
+	/// </summary>
+<# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
+	/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+<# } #>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+	void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null);
+
+<# } #>
+	}
+}

--- a/Src/Metrics/Timer.tt
+++ b/Src/Metrics/Timer.tt
@@ -15,43 +15,43 @@ namespace Metrics
     /// <seealso cref="Histogram"/> and <seealso cref="Meter"/>
     /// </summary>
     public partial interface Timer
-	{
+    {
 <#
 for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 {
-	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
-	var typeList = GetGenericList(typeCount, GenericTypeFormat);
-	var argList = GetGenericList(typeCount, GenericArgumentFormat);
-	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+    var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+    var typeList = GetGenericList(typeCount, GenericTypeFormat);
+    var argList = GetGenericList(typeCount, GenericArgumentFormat);
+    var paramList = GetGenericList(typeCount, GenericParameterFormat);
 #>
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
-	/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
-    /// <typeparam name="TResult"></typeparam>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null);
+        /// <typeparam name="TResult"></typeparam>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        TResult Time<<#= typeList #>, TResult>(Func<<#= typeList #>, TResult> action, <#= argList #>, string userValue = null);
 
 <# } #>
 <#
 for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
 {
-	var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
-	var typeList = GetGenericList(typeCount, GenericTypeFormat);
-	var argList = GetGenericList(typeCount, GenericArgumentFormat);
-	var paramList = GetGenericList(typeCount, GenericParameterFormat);
+    var prevTypeList = GetGenericList(typeCount-1, GenericTypeFormat);
+    var typeList = GetGenericList(typeCount, GenericTypeFormat);
+    var argList = GetGenericList(typeCount, GenericArgumentFormat);
+    var paramList = GetGenericList(typeCount, GenericParameterFormat);
 #>
-	/// <summary>
-	/// Runs the <paramref name="action"/> and records the time it took.
-	/// </summary>
+        /// <summary>
+        /// Runs the <paramref name="action"/> and records the time it took.
+        /// </summary>
 <# for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++) { #>
-	/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
+        /// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> parameter to the <paramref name="action"/> delegate.</typeparam>
 <# } #>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
-	void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1501:AvoidExcessiveInheritance"), SuppressMessage("Microsoft.StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "The classes are related by implementing multiple generic signatures.")]
+        void Time<<#= typeList #>>(Action<<#= typeList #>> action, <#= argList #>, string userValue = null);
 
 <# } #>
-	}
+    }
 }


### PR DESCRIPTION
This pull request adds additional function/action overloads for Timer metrics. The maximum number generic parameters matches the .NET Frameworks for Func<...> and Action<...> which is 16.  The implementation uses a T4 template ~~inspired by~~ stolen from the [Moq](https://github.com/Moq/moq4) framework.

Without this, a user would have to wrap their function in an inline delegate/lambda which becomes problematic with access to variables in closures (ie in foreach loops).