### PR TITLE
Allow dots in context names when reporting to Graphite.

### DIFF
--- a/Src/Metrics/Metric.cs
+++ b/Src/Metrics/Metric.cs
@@ -187,7 +187,7 @@ namespace Metrics
             try
             {
                 var configName = ConfigurationManager.AppSettings["Metrics.GlobalContextName"];
-                var name = string.IsNullOrEmpty(configName) ? Process.GetCurrentProcess().ProcessName : configName;
+                var name = string.IsNullOrEmpty(configName) ? Process.GetCurrentProcess().ProcessName.Replace('.', '_') : configName;
                 log.Debug(() => "Metrics: GlobalContext Name set to " + name);
                 return name;
             }


### PR DESCRIPTION
When I set root context with dots, such as 

    <add key="Metrics.GlobalContextName" value="staging.Test.SamplesConsole"/>

Graphite reporter will replace all dots with underscores and report on metric like this:

    "staging_Test_SamplesConsole.SampleMetrics_DataValue"

It makes impossible to configure metrics hierarchy in Graphana.
This patch makes graphite reporting this instead:

    "staging.Test.SamplesConsole.SampleMetrics_DataValue"
Which preserves dots in context names but still replace them in metric names.