### PR TITLE
Implemented $Env.AppDomainAppVirtualPath$ macro in root context name

### DIFF
--- a/Src/Metrics/Metric.cs
+++ b/Src/Metrics/Metric.cs
@@ -201,7 +201,45 @@ namespace Metrics
 
         private static string ParseGlobalContextName(string configName)
         {
-            return Regex.Replace(configName, @"\$Env\.MachineName\$", Environment.MachineName, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+            configName = Regex.Replace(configName, @"\$Env\.MachineName\$", Environment.MachineName, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+            
+            configName = Regex.Replace(configName, @"\$Env\.ProcessName\$", Process.GetCurrentProcess().ProcessName, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+            const string aspMacro = @"\$Env\.AppDomainAppVirtualPath\$";
+            if (Regex.IsMatch(configName, aspMacro, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase))
+                configName = Regex.Replace(configName, aspMacro, ResolveAspSiteName(), RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+            return configName;
+        }
+
+        /// <summary>
+        /// Try to resolve Asp site name without compile-time linking System.Web assembly.
+        /// </summary>
+        /// <returns>Site name or throw ConfigurationErrorsException if resolution failed</returns>
+        private static string ResolveAspSiteName()
+        {
+            const string error = "Could not resolve $Env.AppDomainAppVirtualPath$ macro";
+            try
+            {
+                var runtimeType = Type.GetType("System.Web.HttpRuntime, System.Web, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", false, true);
+                var result = runtimeType.GetProperty("AppDomainAppVirtualPath").GetValue(null);
+                if (result != null)
+                {
+                    var resultStr = (string)result;
+                    resultStr = resultStr.Trim('/');
+                    if(resultStr != "")
+                        return resultStr;
+
+                    result = runtimeType.GetProperty("AppDomainAppId").GetValue(null);
+                    return ((string)result).Trim('/');
+                }
+
+                throw new ConfigurationErrorsException(error);
+            } 
+            catch(Exception e)
+            {
+                throw new ConfigurationErrorsException(error, e);
+            }
         }
 
         private static string GetDefaultGlobalContextName()

--- a/Src/Metrics/Metrics.csproj
+++ b/Src/Metrics/Metrics.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SharedAssemblyInfo.cs">


### PR DESCRIPTION
Implemented magic name for AppDomainAppVirtualPath macro.
It will be replaced with Asp.Net virtual forlder name. If application is root folder, AppDomainAppId will be used like this: "LM/W3SVC/12/ROOT"