### PR TITLE
Add EntryAssembly name and version to AppEnvironment

### DIFF
--- a/Src/Metrics/Utils/AppEnvironment.cs
+++ b/Src/Metrics/Utils/AppEnvironment.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using Metrics.MetricData;
 using Metrics.Logging;
 
@@ -27,6 +28,9 @@ namespace Metrics.Utils
                 yield return new EnvironmentEntry("HostName", SafeGetString(Dns.GetHostName));
                 yield return new EnvironmentEntry("IPAddress", SafeGetString(GetIpAddress));
                 yield return new EnvironmentEntry("LocalTime", Clock.FormatTimestamp(DateTime.Now));
+                var entryAssemblyName = Assembly.GetEntryAssembly().GetName();
+                yield return new EnvironmentEntry("EntryAssemblyName", entryAssemblyName.Name);
+                yield return new EnvironmentEntry("EntryAssemblyVersion", entryAssemblyName.Version.ToString());
             }
         }
 


### PR DESCRIPTION
Allow the entry assembly name and version to be displayed in the /json endpoint.