### PR TITLE
support setting a prefix for graphite metric names

### DIFF
--- a/Src/Metrics/Graphite/GraphiteExtensions.cs
+++ b/Src/Metrics/Graphite/GraphiteExtensions.cs
@@ -6,39 +6,41 @@ namespace Metrics
 {
     public static class GraphiteExtensions
     {
-        public static MetricsReports WithGraphite(this MetricsReports reports, Uri graphiteUri, TimeSpan interval)
+        public static MetricsReports WithGraphite(this MetricsReports reports, Uri graphiteUri, TimeSpan interval,
+            string metricNamePrefix = null)
         {
             if (graphiteUri.Scheme.ToLowerInvariant() == "net.tcp")
             {
-                return reports.WithTCPGraphite(graphiteUri.Host, graphiteUri.Port, interval);
+                return reports.WithTCPGraphite(graphiteUri.Host, graphiteUri.Port, interval, metricNamePrefix);
             }
 
             if (graphiteUri.Scheme.ToLowerInvariant() == "net.udp")
             {
-                return reports.WithUDPGraphite(graphiteUri.Host, graphiteUri.Port, interval);
+                return reports.WithUDPGraphite(graphiteUri.Host, graphiteUri.Port, interval, metricNamePrefix);
             }
 
             if (graphiteUri.Scheme.ToLowerInvariant() == "net.pickled")
             {
-                return reports.WithPickledGraphite(graphiteUri.Host, graphiteUri.Port, interval);
+                return reports.WithPickledGraphite(graphiteUri.Host, graphiteUri.Port, interval, PickleGraphiteSender.DefaultPickleJarSize, metricNamePrefix);
             }
 
             throw new ArgumentException("Graphite uri scheme must be either net.tcp or net.udp or net.pickled (ex: net.udp://graphite.myhost.com:2003 )", "graphiteUri");
         }
 
-        public static MetricsReports WithPickledGraphite(this MetricsReports reports, string host, int port, TimeSpan interval, int batchSize = PickleGraphiteSender.DefaultPickleJarSize)
+        public static MetricsReports WithPickledGraphite(this MetricsReports reports, string host, int port, TimeSpan interval, int batchSize = PickleGraphiteSender.DefaultPickleJarSize,
+            string metricNamePrefix = null)
         {
-            return reports.WithGraphite(new PickleGraphiteSender(host, port, batchSize), interval);
+            return reports.WithGraphite(new PickleGraphiteSender(host, port, batchSize, metricNamePrefix), interval);
         }
 
-        public static MetricsReports WithTCPGraphite(this MetricsReports reports, string host, int port, TimeSpan interval)
+        public static MetricsReports WithTCPGraphite(this MetricsReports reports, string host, int port, TimeSpan interval, string metricNamePrefix = null)
         {
-            return reports.WithGraphite(new TcpGraphiteSender(host, port), interval);
+            return reports.WithGraphite(new TcpGraphiteSender(host, port, metricNamePrefix), interval);
         }
 
-        public static MetricsReports WithUDPGraphite(this MetricsReports reports, string host, int port, TimeSpan interval)
+        public static MetricsReports WithUDPGraphite(this MetricsReports reports, string host, int port, TimeSpan interval, string metricNamePrefix = null)
         {
-            return reports.WithGraphite(new UdpGraphiteSender(host, port), interval);
+            return reports.WithGraphite(new UdpGraphiteSender(host, port, metricNamePrefix), interval);
         }
 
         public static MetricsReports WithGraphite(this MetricsReports reports, GraphiteSender graphiteLink, TimeSpan interval)

--- a/Src/Metrics/Graphite/GraphiteSender.cs
+++ b/Src/Metrics/Graphite/GraphiteSender.cs
@@ -4,9 +4,11 @@ namespace Metrics.Graphite
 {
     public abstract class GraphiteSender : IDisposable
     {
+        protected string MetricNamePrefix;
         public virtual void Send(string name, string value, string timestamp)
         {
-            var data = string.Concat(name, " ", value, " ", timestamp, "\n");
+            var metricName = string.IsNullOrEmpty(MetricNamePrefix) ? name : string.Format("{0}.{1}", MetricNamePrefix, name);
+            var data = string.Concat(metricName, " ", value, " ", timestamp, "\n");
             SendData(data);
         }
 

--- a/Src/Metrics/Graphite/PickleGraphiteSender.cs
+++ b/Src/Metrics/Graphite/PickleGraphiteSender.cs
@@ -21,11 +21,12 @@ namespace Metrics.Graphite
         private PickleJar jar = new PickleJar();
 
 
-        public PickleGraphiteSender(string host, int port, int batchSize = DefaultPickleJarSize)
+        public PickleGraphiteSender(string host, int port, int batchSize = DefaultPickleJarSize, string metricNamePrefix = null)
         {
             this.host = host;
             this.port = port;
             this.pickleJarSize = batchSize;
+            this.MetricNamePrefix = metricNamePrefix;
         }
 
         public override void Send(string name, string value, string timestamp)

--- a/Src/Metrics/Graphite/TcpGraphiteSender.cs
+++ b/Src/Metrics/Graphite/TcpGraphiteSender.cs
@@ -16,10 +16,11 @@ namespace Metrics.Graphite
 
         private TcpClient client;
 
-        public TcpGraphiteSender(string host, int port)
+        public TcpGraphiteSender(string host, int port, string metricNamePrefix = null)
         {
             this.host = host;
             this.port = port;
+            this.MetricNamePrefix = metricNamePrefix;
         }
 
         protected override void SendData(string data)

--- a/Src/Metrics/Graphite/UdpGraphiteSender.cs
+++ b/Src/Metrics/Graphite/UdpGraphiteSender.cs
@@ -16,10 +16,11 @@ namespace Metrics.Graphite
 
         private UdpClient client;
 
-        public UdpGraphiteSender(string host, int port)
+        public UdpGraphiteSender(string host, int port, string metricNamePrefix = null)
         {
             this.host = host;
             this.port = port;
+            this.MetricNamePrefix = metricNamePrefix;
         }
 
         protected override void SendData(string data)
@@ -43,7 +44,7 @@ namespace Metrics.Graphite
         }
 
         public override void Flush()
-        { 
+        {
         }
 
         private static UdpClient InitClient(string host, int port)


### PR DESCRIPTION
Prefix Graphite metric names with a user specified value. This allows for adding API keys or other top level designations to all metrics transmitted to Graphite