### PR TITLE
Introduce non-static HealthChecksRegistry

### DIFF
--- a/Src/Metrics.Tests/HealthChecksTests/HealthCheckRegistryTests.cs
+++ b/Src/Metrics.Tests/HealthChecksTests/HealthCheckRegistryTests.cs
@@ -10,18 +10,18 @@ namespace Metrics.Tests.HealthChecksTests
         [Fact]
         public void HealthCheck_RegistryExecutesCheckOnEachGetStatus()
         {
-            HealthChecks.UnregisterAllHealthChecks();
+            HealthCheckRegistry registry = new HealthCheckRegistry();
             int count = 0;
 
-            HealthChecks.RegisterHealthCheck(new HealthCheck("test", () => { count++; }));
+            registry.RegisterHealthCheck(new HealthCheck("test", () => { count++; }));
 
             count.Should().Be(0);
 
-            HealthChecks.GetStatus();
+            registry.GetStatus();
 
             count.Should().Be(1);
 
-            HealthChecks.GetStatus();
+            registry.GetStatus();
 
             count.Should().Be(2);
         }
@@ -29,12 +29,12 @@ namespace Metrics.Tests.HealthChecksTests
         [Fact]
         public void HealthCheck_RegistryStatusIsFailedIfOneCheckFails()
         {
-            HealthChecks.UnregisterAllHealthChecks();
+            HealthCheckRegistry registry = new HealthCheckRegistry();
 
-            HealthChecks.RegisterHealthCheck(new HealthCheck("ok", () => { }));
-            HealthChecks.RegisterHealthCheck(new HealthCheck("bad", () => HealthCheckResult.Unhealthy()));
+            registry.RegisterHealthCheck(new HealthCheck("ok", () => { }));
+            registry.RegisterHealthCheck(new HealthCheck("bad", () => HealthCheckResult.Unhealthy()));
 
-            var status = HealthChecks.GetStatus();
+            var status = registry.GetStatus();
 
             status.IsHealthy.Should().BeFalse();
             status.Results.Length.Should().Be(2);
@@ -43,12 +43,12 @@ namespace Metrics.Tests.HealthChecksTests
         [Fact]
         public void HealthCheck_RegistryStatusIsHealthyIfAllChecksAreHealthy()
         {
-            HealthChecks.UnregisterAllHealthChecks();
+            HealthCheckRegistry registry = new HealthCheckRegistry();
 
-            HealthChecks.RegisterHealthCheck(new HealthCheck("ok", () => { }));
-            HealthChecks.RegisterHealthCheck(new HealthCheck("another", () => HealthCheckResult.Healthy()));
+            registry.RegisterHealthCheck(new HealthCheck("ok", () => { }));
+            registry.RegisterHealthCheck(new HealthCheck("another", () => HealthCheckResult.Healthy()));
 
-            var status = HealthChecks.GetStatus();
+            var status = registry.GetStatus();
 
             status.IsHealthy.Should().BeTrue();
             status.Results.Length.Should().Be(2);
@@ -57,11 +57,11 @@ namespace Metrics.Tests.HealthChecksTests
         [Fact]
         public void HealthCheck_RegistryDoesNotThrowOnDuplicateRegistration()
         {
-            HealthChecks.UnregisterAllHealthChecks();
+            HealthCheckRegistry registry = new HealthCheckRegistry();
 
-            HealthChecks.RegisterHealthCheck(new HealthCheck("test", () => { }));
+            registry.RegisterHealthCheck(new HealthCheck("test", () => { }));
 
-            Action action = () => HealthChecks.RegisterHealthCheck(new HealthCheck("test", () => { }));
+            Action action = () => registry.RegisterHealthCheck(new HealthCheck("test", () => { }));
             action.ShouldNotThrow<InvalidOperationException>();
         }
     }

--- a/Src/Metrics/MetricsConfig.cs
+++ b/Src/Metrics/MetricsConfig.cs
@@ -22,13 +22,13 @@ namespace Metrics
 
         private bool isDisabled = MetricsConfig.GlobalyDisabledMetrics;
 
-        public MetricsConfig(MetricsContext context)
+        public MetricsConfig(MetricsContext context, Func<HealthStatus> healthStatus = null)
         {
             this.context = context;
 
             if (!GlobalyDisabledMetrics)
             {
-                this.healthStatus = HealthChecks.GetStatus;
+                this.healthStatus = healthStatus ?? HealthChecks.GetStatus;
                 this.reports = new MetricsReports(this.context.DataProvider, this.healthStatus);
                 this.context.Advanced.ContextDisabled += (s, e) =>
                 {


### PR DESCRIPTION
Original java metrics lib contains non-static registries for Metrics and Health checks.
Having the ability to pass a non-static instance allows to use separate metrics for different applications within the same AppDomain. 

In short: pull request provides a way to avoid static mutable state for consumers.
