### PR TITLE
Implement InfluxDB 0.9.1+ line protocol

### DIFF
--- a/Src/Metrics/Influxdb/InfluxdbConfigExtensions.cs
+++ b/Src/Metrics/Influxdb/InfluxdbConfigExtensions.cs
@@ -8,12 +8,12 @@ namespace Metrics
     {
         public static MetricsReports WithInfluxDb(this MetricsReports reports, string host, int port, string user, string pass, string database, TimeSpan interval)
         {
-            return reports.WithInfluxDb(new Uri(string.Format(@"http://{0}:{1}/db/{2}/series?u={3}&p={4}&time_precision=s", host, port, database, user, pass)), interval);
+            return reports.WithInfluxDb(new Uri(string.Format(@"http://{0}:{1}/write?db={2}", host, port, database)), user, pass, interval);
         }
 
-        public static MetricsReports WithInfluxDb(this MetricsReports reports, Uri influxdbUri, TimeSpan interval)
+        public static MetricsReports WithInfluxDb(this MetricsReports reports, Uri influxdbUri, string username, string password, TimeSpan interval)
         {
-            return reports.WithReport(new InfluxdbReport(influxdbUri), interval);
+            return reports.WithReport(new InfluxdbReport(influxdbUri, username, password), interval);
         }
     }
 }

--- a/Src/Metrics/Metrics.csproj
+++ b/Src/Metrics/Metrics.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SharedAssemblyInfo.cs">


### PR DESCRIPTION
InfluxDB deprecated the JSON data format in 0.9.1, and is no longer ~~supported~~ working in the latest. This change implements that new protocol. Additionally, moves from WebClient to async posting via HttpClient. (This should be considered alpha at this point.)
