### PR TITLE
Resetting reservoir's count only when snapshot was created

### DIFF
--- a/Src/Metrics/Sampling/SlidingWindowReservoir.cs
+++ b/Src/Metrics/Sampling/SlidingWindowReservoir.cs
@@ -45,16 +45,16 @@ namespace Metrics.Sampling
             UserValueWrapper[] values = new UserValueWrapper[size];
             Array.Copy(this.values, values, size);
 
+            Array.Sort(values, UserValueWrapper.Comparer);
+            var minValue = values[0].UserValue;
+            var maxValue = values[size - 1].UserValue;
+            var snapshot = new UniformSnapshot(this.count.Value, values.Select(v => v.Value), valuesAreSorted: true, minUserValue: minValue, maxUserValue: maxValue);
             if (resetReservoir)
             {
                 Array.Clear(this.values, 0, values.Length);
                 count.SetValue(0L);
             }
-
-            Array.Sort(values, UserValueWrapper.Comparer);
-            var minValue = values[0].UserValue;
-            var maxValue = values[size - 1].UserValue;
-            return new UniformSnapshot(this.count.Value, values.Select(v => v.Value), valuesAreSorted: true, minUserValue: minValue, maxUserValue: maxValue);
+            return snapshot;
         }
     }
 }

--- a/Src/Metrics/Sampling/UniformReservoir.cs
+++ b/Src/Metrics/Sampling/UniformReservoir.cs
@@ -43,15 +43,15 @@ namespace Metrics.Sampling
             UserValueWrapper[] values = new UserValueWrapper[size];
             Array.Copy(this.values, values, size);
 
+            Array.Sort(values, UserValueWrapper.Comparer);
+            var minValue = values[0].UserValue;
+            var maxValue = values[size - 1].UserValue;
+            var snapshot = new UniformSnapshot(this.count.Value, values.Select(v => v.Value), valuesAreSorted: true, minUserValue: minValue, maxUserValue: maxValue);
             if (resetReservoir)
             {
                 count.SetValue(0L);
             }
-
-            Array.Sort(values, UserValueWrapper.Comparer);
-            var minValue = values[0].UserValue;
-            var maxValue = values[size - 1].UserValue;
-            return new UniformSnapshot(this.count.Value, values.Select(v => v.Value), valuesAreSorted: true, minUserValue: minValue, maxUserValue: maxValue);
+            return snapshot;
         }
 
         public void Update(long value, string userValue = null)


### PR DESCRIPTION
SlidingWindowReservoir and UniformReservoir were resetting count field before creating a snapshot which means that snapshot's Count always was equals to 0.